### PR TITLE
call the role with escalated privilege

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,11 +4,9 @@
     name: "zabbix-agent2"
     state: restarted
     enabled: true
-  become: true
 - name: "restart zabbix-agent"
   service:
     name: "zabbix-agent"
     state: restarted
     enabled: true
-  become: true
 ...

--- a/tasks/configure-zabbix-agent.yml
+++ b/tasks/configure-zabbix-agent.yml
@@ -6,7 +6,6 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  become: true
   when: is_agent2
   notify: "restart zabbix-agent2"
 - name: "Set zabbix-agent configuration file"
@@ -16,7 +15,6 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  become: true
   when: not is_agent2
   notify: "restart zabbix-agent"
 ...

--- a/tasks/install-zabbix-agent-Debian.yml
+++ b/tasks/install-zabbix-agent-Debian.yml
@@ -5,27 +5,22 @@
     update_cache: true
     autoremove: true
     state: present
-  become: true
 - name: "Reload Facts"
   setup:
     gather_subset: "min,local"
-  become: true
 - name: "Add zabbix repo key"
   apt_key:
     url: "{{ zabbix_repo_key }}"
     state: present
-  become: true
 - name: "Enable Zabbix repos"
   apt_repository:
     repo: "deb [arch={{ repo_arch }}] {{ repo_url }} {{ ansible_lsb.codename }} main"
     state: present
     filename: "zabbix"
-  become: true
 - name: "Install required packages"
   apt:
     name: "{{ pkglist }}"
     update_cache: true
     autoremove: true
     state: present
-  become: true
 ...

--- a/tasks/install-zabbix-agent-RedHat.yml
+++ b/tasks/install-zabbix-agent-RedHat.yml
@@ -7,10 +7,8 @@
     baseurl: "{{ repo_url }}"
     gpgcheck: true
     gpgkey: "{{ zabbix_rpm_gpg_key }}"
-  become: true
 - name: "Install required packages"
   package:
     name: "{{ pkglist }}"
     state: present
-  become: true
 ...


### PR DESCRIPTION
To keep it simple, all the actions need privilege escalation. So managing the escalation before calling the role greatly simplifies the code.